### PR TITLE
change searchbox in torrents.php to fold by default instead of open.

### DIFF
--- a/public/torrents.php
+++ b/public/torrents.php
@@ -881,9 +881,9 @@ if ($allsec != 1 || $enablespecial != 'yes'){ //do not print searchbox if showin
 	<table border="1" class="searchbox" cellspacing="0" cellpadding="5" width="100%">
 		<tbody>
 		<tr>
-		<td class="colhead" align="center" colspan="2"><a href="javascript: klappe_news('searchboxmain')"><img class="minus" src="pic/trans.gif" id="picsearchboxmain" alt="Show/Hide" /><?php echo $lang_torrents['text_search_box'] ?></a></td>
+		<td class="colhead" align="center" colspan="2"><a href="javascript: klappe_news('searchboxmain')"><img class="plus" src="pic/trans.gif" id="picsearchboxmain" alt="Show/Hide" /><?php echo $lang_torrents['text_search_box'] ?></a></td>
 		</tr></tbody>
-		<tbody id="ksearchboxmain">
+		<tbody id="ksearchboxmain" style="display:none">
 		<tr>
 			<td class="rowfollow" align="left">
 				<table>


### PR DESCRIPTION
./torrents.php default show style change :

current:
<img width="664" alt="image" src="https://user-images.githubusercontent.com/8529346/109902711-c92d4e80-7cd5-11eb-8552-106649676866.png">

fixed:
<img width="811" alt="image" src="https://user-images.githubusercontent.com/8529346/109902747-d9452e00-7cd5-11eb-9fef-b5c746b4e3f7.png">

