### PR TITLE
add static variable for Setting::get

### DIFF
--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -29,6 +29,8 @@ class Setting extends NexusModel
      */
     public static function get($name = null, $default = null): mixed
     {
+        static $settings=null;
+        if(is_null($settings))
         $settings = NexusDB::remember("nexus_settings_in_laravel", 600, function () {
             return self::getFromDb();
         });

--- a/include/globalfunctions.php
+++ b/include/globalfunctions.php
@@ -710,11 +710,13 @@ function get_row_count($table, $suffix = "")
 function get_user_row($id)
 {
     global $Cache, $CURUSER;
+    static $userRows=[];
     static $curuserRowUpdated = false;
     static $neededColumns = array(
         'id', 'noad', 'class', 'enabled', 'privacy', 'avatar', 'signature', 'uploaded', 'downloaded', 'last_access', 'username', 'donor',
         'donoruntil', 'leechwarn', 'warned', 'title', 'downloadpos', 'parked', 'clientselect', 'showclienterror',
     );
+    if(isset($userRows[$id]))return $userRows[$id];
     $cacheKey = 'user_'.$id.'_content';
     $row = \Nexus\Database\NexusDB::remember($cacheKey, 3600, function () use ($id, $neededColumns) {
         $user = \App\Models\User::query()->with(['wearing_medals'])->find($id, $neededColumns);
@@ -751,7 +753,7 @@ function get_user_row($id)
 
     if (!$row)
         return false;
-    else return $row;
+    else return $userRows[$id]=$row;
 }
 
 function get_user_class()


### PR DESCRIPTION
Add static variable cache for Setting::get , to avoid unnecessary reading of Redis.
This patch can significantly decrease the amount of read times and page creating time.

为配置读取增加静态变量缓存，减少不必要的Redis读取.
这能够大幅降低各个页面的Redis读取次数，并且加快各页面的响应速度

Before

<img width="582" alt="image" src="https://user-images.githubusercontent.com/28647007/207969200-feab3daa-ccfa-4ce3-a3db-78d1f45d6d81.png">

After

<img width="533" alt="image" src="https://user-images.githubusercontent.com/28647007/207969517-819fa939-bd8b-4628-af89-c0a61354b436.png">

