### PR TITLE
fix:修复发种界面质量的子选项未正确排序问题

### DIFF
--- a/app/Repositories/SearchBoxRepository.php
+++ b/app/Repositories/SearchBoxRepository.php
@@ -176,7 +176,7 @@ class SearchBoxRepository extends BaseRepository
             $select .= sprintf('<option value="%s">%s</option>', 0, nexus_trans('nexus.select_one_please'));
             $list = NexusDB::table($table)->where(function (Builder $query) use ($searchBox) {
                 return $query->where('mode', $searchBox->id)->orWhere('mode', 0);
-            })->get();
+            })->orderBy('sort_index')->get();
             foreach ($list as $item) {
                 $selected = '';
                 if (isset($torrentInfo[$torrentField]) && $torrentInfo[$torrentField] == $item->id) {


### PR DESCRIPTION
发种界面中质量区的媒介、编码、分辨率、制作组等没有正确按照排序号排序，所以在查询中加上了排序。