### PR TITLE
fix staffbox pagination

### DIFF
--- a/public/staffbox.php
+++ b/public/staffbox.php
@@ -50,7 +50,7 @@ if (!$action) {
 			<td class=colhead align=center><nobr>".$lang_staffbox['col_action']."</nobr></td>
 		</tr>");
 
-	$res = $query->forPage($pageNum, $perpage)->orderBy('id', 'desc')->get()->toArray();
+	$res = $query->forPage($pageNum + 1, $perpage)->orderBy('id', 'desc')->get()->toArray();
 	do_log(last_query());
 	foreach ($res as $arr)
 	{


### PR DESCRIPTION
问题：管理组信箱前二页内容重复，内容与页码对不上

原因：functions.php中pager()的页码从0开始，collection->forPage()的页码从1开始