### PR TITLE
Fix ip banned feedback & modcomment texts

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -1610,7 +1610,7 @@ function failedloginscheck ($type = 'Login') {
 	list($total) = mysql_fetch_array($Query);
 	if ($total >= $maxloginattempts) {
 		sql_query("UPDATE loginattempts SET banned = 'yes' WHERE ip=$ip") or sqlerr(__FILE__, __LINE__);
-		stderr($type.$lang_functions['std_locked'].$type.$lang_functions['std_attempts_reached'], $lang_functions['std_your_ip_banned'], true, true);
+		stderr($type.$lang_functions['std_locked'].$maxloginattempts.$lang_functions['std_attempts_reached'], $lang_functions['std_your_ip_banned'], true, true);
 	}
 }
 function failedlogins ($type = 'login', $recover = false, $head = true)

--- a/public/modtask.php
+++ b/public/modtask.php
@@ -115,7 +115,7 @@ if ($action == "edituser")
 		}
 		if ($arr['username'] != $username){
 			$updateset[] = "username = " . sqlesc($username);
-			$modcomment = date("Y-m-d") . " - Usernmae changed from $arr[username] to $username by {$CURUSER['username']}.\n". $modcomment;
+			$modcomment = date("Y-m-d") . " - Username changed from $arr[username] to $username by {$CURUSER['username']}.\n". $modcomment;
 			$subject = sqlesc($lang_modtask_target[get_user_lang($userid)]['msg_username_change']);
 			$msg = sqlesc($lang_modtask_target[get_user_lang($userid)]['msg_your_username_changed_from'].$arr['username'].$lang_modtask_target[get_user_lang($userid)]['msg_to_new'] . $username .$lang_modtask_target[get_user_lang($userid)]['msg_by'].$CURUSER['username']);
 			sql_query("INSERT INTO messages (sender, receiver, subject, msg, added) VALUES(0, $userid, $subject, $msg, $added)") or sqlerr(__FILE__, __LINE__);


### PR DESCRIPTION
1. 修复了登录失败次数过多导致ip被封禁后的提示（应显示最大登录次数处错误地显示了操作（如Login））
2. 修复了管理组修改用户名后自动添加的备注中的拼写错误