### PR TITLE
Fixed Tracker compact return issue when accessing via ipv6

### DIFF
--- a/public/announce.php
+++ b/public/announce.php
@@ -115,8 +115,6 @@ $ip = getip();	// avoid to get the spoof ip from some agent
 $_GET['ip'] = $ip;
 if (!$port || $port > 0xffff)
 	warn("invalid port");
-if (!ip2long($ip)) //Disable compact announce with IPv6
-	$compact = 0;
 
 $ipv4 = $ipv6 = '';
 if (isIPV4($ip)) {


### PR DESCRIPTION
Already have peers6 parameters, which should NOT disable compact announce with IPv6. 

If not modified, the parameter compact=1 requested via ipv6 will be ignored.

Thanks to @Zipper-1 for reporting this issue.