### PR TITLE
Exam tag url change and rich businessTypes

### DIFF
--- a/app/Models/BonusLogs.php
+++ b/app/Models/BonusLogs.php
@@ -66,6 +66,8 @@ class BonusLogs extends NexusModel
         self::BUSINESS_TYPE_BUY_CHANGE_USERNAME_CARD => ['text' => 'Buy change username card'],
         self::BUSINESS_TYPE_GIFT_MEDAL => ['text' => 'Gift medal to someone'],
         self::BUSINESS_TYPE_BUY_TORRENT => ['text' => 'Buy torrent'],
+        self::BUSINESS_TYPE_TASK_NOT_PASS_DEDUCT => ['text' => 'Task failure penalty'],
+        self::BUSINESS_TYPE_TASK_PASS_REWARD => ['text' => 'Task success reward'],
 
         self::BUSINESS_TYPE_ROLE_WORK_SALARY => ['text' => 'Role work salary'],
         self::BUSINESS_TYPE_TORRENT_BE_DOWNLOADED => ['text' => 'Torrent be downloaded'],

--- a/include/functions.php
+++ b/include/functions.php
@@ -2910,7 +2910,7 @@ if ($msgalert)
     $exam = new \Nexus\Exam\Exam();
     $currentExam = $exam->getCurrent($CURUSER['id']);
     if (!empty($currentExam['html'])) {
-        msgalert("messages.php", $currentExam['html'], $currentExam['exam']->background_color ?? 'blue');
+        msgalert($currentExam['exam']->type==\App\Models\Exam::TYPE_TASK ? "task.php" : "messages.php", $currentExam['html'], $currentExam['exam']->background_color ?? 'blue');
     }
 }
 		if ($offlinemsg)


### PR DESCRIPTION
1. Exam's tag jump to task.php instead of messages.php when the exam type is task
2. add BUSINESS_TYPE_TASK_NOT_PASS_DEDUCT and BUSINESS_TYPE_TASK_PASS_REWARD to BonusLogs::$businessTypes
