### PR TITLE
Fix the effect of paths on menu selections

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -2242,7 +2242,7 @@ function menu ($selected = "home") {
 	global $USERUPDATESET;
 	//no this option in config.php
     $enablerequest = 'yes';
-	$script_name = $_SERVER["SCRIPT_FILENAME"];
+	$script_name = $_SERVER["SCRIPT_NAME"];
 	if (preg_match("/index/i", $script_name)) {
 		$selected = "home";
 	}elseif (preg_match("/forums/i", $script_name)) {


### PR DESCRIPTION
1panel 文件路径默认在index下，导致部署后首页永远高亮显示