### PR TITLE
Fix Filament UserPasskeyResource compatibility

### DIFF
--- a/app/Filament/Resources/User/UserPasskeyResource.php
+++ b/app/Filament/Resources/User/UserPasskeyResource.php
@@ -4,9 +4,11 @@ namespace App\Filament\Resources\User;
 
 use App\Filament\Resources\User\UserPasskeyResource\Pages;
 use App\Models\Passkey;
-use Filament\Forms;
-use Filament\Forms\Form;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -15,9 +17,9 @@ class UserPasskeyResource extends Resource
 {
     protected static ?string $model = Passkey::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-key';
+    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-key';
 
-    protected static ?string $navigationGroup = 'User';
+    protected static string | \UnitEnum | null $navigationGroup = 'User';
 
     protected static ?int $navigationSort = 12;
 
@@ -31,10 +33,10 @@ class UserPasskeyResource extends Resource
         return self::getNavigationLabel();
     }
 
-    public static function form(Form $form): Form
+    public static function form(Schema $schema): Schema
     {
-        return $form
-            ->schema([
+        return $schema
+            ->components([
                 //
             ]);
     }
@@ -66,7 +68,7 @@ class UserPasskeyResource extends Resource
             ->filters([
                 Tables\Filters\Filter::make('user_id')
                     ->form([
-                        Forms\Components\TextInput::make('uid')
+                        TextInput::make('uid')
                             ->label(__('label.username'))
                             ->placeholder('UID')
                         ,
@@ -76,7 +78,7 @@ class UserPasskeyResource extends Resource
                 ,
                 Tables\Filters\Filter::make('credential_id')
                     ->form([
-                        Forms\Components\TextInput::make('credential_id')
+                        TextInput::make('credential_id')
                             ->label(__('passkey.fields.credential_id'))
                             ->placeholder('Credential ID')
                         ,
@@ -85,11 +87,11 @@ class UserPasskeyResource extends Resource
                     })
                 ,
             ])
-            ->actions([
-                Tables\Actions\DeleteAction::make(),
+            ->recordActions([
+                DeleteAction::make(),
             ])
-            ->bulkActions([
-                Tables\Actions\DeleteBulkAction::make(),
+            ->toolbarActions([
+                DeleteBulkAction::make(),
             ]);
     }
 


### PR DESCRIPTION
This pull request updates the `UserPasskeyResource` to align with the latest Filament API changes and improves code clarity. The most important changes include updating type hints to support enums, switching to new Filament component imports, and refactoring table actions to use the latest API conventions.

**Filament API Updates:**

* Updated type hints for `navigationIcon` and `navigationGroup` to support enums, improving compatibility with Filament v3. (`app/Filament/Resources/User/UserPasskeyResource.php`)
* Changed method signatures and usages from `Form` and `Forms\Components\TextInput` to `Schema` and `TextInput`, reflecting Filament's new form and filter component conventions. (`app/Filament/Resources/User/UserPasskeyResource.php`) [[1]](diffhunk://#diff-fc7b407b0edaef4668ce7c5f7e97a5c533434f51cfee7819b6e7c1695806f627L34-R39) [[2]](diffhunk://#diff-fc7b407b0edaef4668ce7c5f7e97a5c533434f51cfee7819b6e7c1695806f627L69-R71) [[3]](diffhunk://#diff-fc7b407b0edaef4668ce7c5f7e97a5c533434f51cfee7819b6e7c1695806f627L79-R81)

**Table Actions Refactor:**

* Replaced `actions` and `bulkActions` with `recordActions` and `toolbarActions`, and switched to direct imports of `DeleteAction` and `DeleteBulkAction`, following Filament's latest table API. (`app/Filament/Resources/User/UserPasskeyResource.php`)

These changes help keep the resource definition up-to-date with Filament best practices and ensure future compatibility.